### PR TITLE
Fix wifi_getRadioEnable

### DIFF
--- a/source/wifi/wifi_hal.c
+++ b/source/wifi/wifi_hal.c
@@ -1032,8 +1032,6 @@ INT wifi_getRadioEnable(INT radioIndex, BOOL *output_bool)      //RDKB
                *output_bool=TRUE;
 
         //TODO: check if hostapd with config is running
-
-        *output_bool = FALSE;
         return RETURN_OK;
 }
 

--- a/source/wifi/wifi_hal.c
+++ b/source/wifi/wifi_hal.c
@@ -1018,6 +1018,8 @@ INT wifi_getRadioEnable(INT radioIndex, BOOL *output_bool)      //RDKB
         if (NULL == output_bool)
                 return RETURN_ERR;
 
+        *output_bool = FALSE;
+
         // Check only supported radios
         if (!((radioIndex == 0) || (radioIndex == 1)))
                 return RETURN_ERR;


### PR DESCRIPTION
Currently it sets default to be disabled. Webui shows both WiFi are grey out.

Removed the default value and tested to see both WiFi are enabled.