### PR TITLE
Add suport for more APs

### DIFF
--- a/source/wifi/wifi_hal.c
+++ b/source/wifi/wifi_hal.c
@@ -3743,7 +3743,7 @@ INT wifi_getApNumDevicesAssociated(INT apIndex, ULONG *output_ulong)
     char cmd[128]={0};
     char buf[128]={0};
 
-    if(apIndex > 3) //Currently supporting apIndex upto 3
+    if(apIndex > MAX_APS)
         return RETURN_ERR;
     //sprintf(cmd, "iw dev %s%d station dump | grep Station | wc -l", AP_PREFIX, apIndex);//alternate method
     sprintf(cmd, "hostapd_cli -i %s%d list_sta | wc -l", AP_PREFIX, apIndex);
@@ -5380,7 +5380,7 @@ INT wifi_getApAssociatedDeviceDiagnosticResult3(INT apIndex, wifi_associated_dev
     *output_array_size = 0;
     *associated_dev_array = NULL;
 
-    if (apIndex<0 || apIndex>3) //Currently supporting apIndex upto 3
+    if (apIndex<0 || apIndex>MAX_APS)
         return RETURN_ERR;
 
     wifi_getApNumDevicesAssociated(apIndex, output_array_size);


### PR DESCRIPTION
wifi_getApAssociatedDeviceDiagnosticResult3 and
wifi_getApNumDevicesAssociated supports now MAX_APS APs.