### PR TITLE
Add wifi_getApInterworkingElement stub function

### DIFF
--- a/source/wifi/wifi_hal.c
+++ b/source/wifi/wifi_hal.c
@@ -8028,6 +8028,11 @@ INT wifi_setNeighborReports(UINT apIndex,
     return RETURN_OK;
 }
 
+INT wifi_getApInterworkingElement(INT apIndex, wifi_InterworkingElement_t *output_struct)
+{
+    return RETURN_OK;
+}
+
 #ifdef _WIFI_HAL_TEST_
 int main(int argc,char **argv)
 {


### PR DESCRIPTION
This is fixing turris omnia dunfell build where ccspwifiagent crashes on
210625-11:45:43.423176 [mod=WIFI, lvl=WARN] [tid=11175] Unable to load library -- libwifi.so
210625-11:45:43.423274 [mod=WIFI, lvl=WARN] [tid=11175] cause:/usr/lib/libwifi.so: undefined symbol: wifi_getApInterworkingElement