### PR TITLE
Add dummy get_current_wan_ifname

### DIFF
--- a/source/platform/platform_hal.c
+++ b/source/platform/platform_hal.c
@@ -157,3 +157,9 @@ INT platform_hal_GetRouterRegion(CHAR* pValue)
 {
 	return RETURN_OK;
 }
+
+/* Utility apis to return common parameters from firewall_lib.c */
+char *get_current_wan_ifname()
+{
+    return "0";
+}


### PR DESCRIPTION
Required by Utopia/63233
RDKB-38120 : Close NTP destination port on erouter0 for New Connections

Reason for change: Close Security Violation
Test Procedure: NA
Risks:Low

Signed-off-by: vgnana429 <Vijayan_Gnanamoorthy@comcast.com>