### PR TITLE
Updating hal-ethsw for wanmanager integeration

### DIFF
--- a/source/hal-ethsw/ccsp_hal_ethsw.c
+++ b/source/hal-ethsw/ccsp_hal_ethsw.c
@@ -21,6 +21,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <stdbool.h>
 
 #include "ccsp_hal_ethsw.h" 
 
@@ -32,9 +36,19 @@
 #define  CcspHalEthSwTrace(msg)                     printf("%s - ", __FUNCTION__); printf msg;
 #define MAX_BUF_SIZE 1024
 #define MACADDRESS_SIZE 6
+#define ETH_WAN_INTERFACE  "erouter0"
 #define LM_ARP_ENTRY_FORMAT  "%63s %63s %63s %63s %17s %63s"
 
 #define  ETH_WAN_IFNAME   "eth0"
+
+#if defined(FEATURE_RDKB_WAN_MANAGER)
+static pthread_t ethsw_tid;
+static int hal_init_done = 0;
+appCallBack ethWanCallbacks;
+#define  ETH_INITIALIZE  "/tmp/ethagent_initialized"
+#define  LINK_VALUE_SIZE  50
+#define  ETH_WAN_IFNAME   "eth2"
+#endif
 
 /**********************************************************************
                             MAIN ROUTINES
@@ -52,6 +66,107 @@ int is_interface_exists(const char *fname)
     }
         return 0;
 }
+
+#if defined(FEATURE_RDKB_WAN_MANAGER)
+void *ethsw_thread_main(void *context __attribute__((unused)))
+{
+   FILE *fp = NULL;
+   char command[128] = {0};
+   char* buff = NULL, *pLink;
+   char previousLinkDetected[10]="no";
+   int timeout = 0;
+   int file = 0;
+
+   buff = malloc(sizeof(char)*50);
+   if(buff == NULL)
+    {
+        return (void *) 1;
+    }
+
+   while(timeout != 180)
+    {
+       if (file == access(ETH_INITIALIZE, R_OK))
+       {
+            CcspHalEthSwTrace(("Eth agent initialized \n"));
+            break;
+       }
+       else
+       {
+           timeout = timeout+1;
+           sleep(1);
+       }
+    }
+
+   while(1)
+    {
+        memset(buff,0,sizeof(buff));
+        snprintf(command,128, "ethtool erouter0 | grep \"Link detected\" | cut -d ':' -f2 | cut -d ' ' -f2");
+        fp = popen(command, "r");
+          if (fp == NULL)
+          {
+                continue;
+          }
+          while (fgets(buff, LINK_VALUE_SIZE, fp) != NULL)
+          {
+                pLink = strchr(buff, '\n');
+                if(pLink)
+                    *pLink = '\0';
+          }
+          pclose(fp);
+        if (strcmp(buff, (const char *)previousLinkDetected))
+        {
+            if (strcmp(buff, "yes") == 0)
+	    {
+		CcspHalEthSwTrace(("send_link_event: Got Link UP Event\n"));
+                ethWanCallbacks.pGWP_act_EthWanLinkUP();    
+            }
+            else
+            {
+		 CcspHalEthSwTrace(("send_link_event: Got Link DOWN Event\n"));
+                 ethWanCallbacks.pGWP_act_EthWanLinkDown();   
+            }
+            memset(previousLinkDetected, 0, sizeof(previousLinkDetected));
+            strcpy((char *)previousLinkDetected, buff);
+        }
+        sleep(5);
+    }
+    if(buff != NULL)
+        free(buff);
+    return NULL;
+}
+
+void GWP_RegisterEthWan_Callback(appCallBack *obj) {
+    int rc;
+
+    if (obj == NULL) {
+        rc = RETURN_ERR;
+    } else {
+        ethWanCallbacks.pGWP_act_EthWanLinkUP = obj->pGWP_act_EthWanLinkUP;
+        ethWanCallbacks.pGWP_act_EthWanLinkDown = obj->pGWP_act_EthWanLinkDown;
+        rc = RETURN_OK;
+    }
+
+    return;
+}
+
+INT
+    GWP_GetEthWanInterfaceName
+(
+ unsigned char * Interface,
+ ULONG           maxSize
+ )
+{
+    //Maxsize param should be minimum 4charecters(eth0) including NULL charecter	
+    if( ( Interface == NULL ) || ( maxSize < ( strlen( ETH_WAN_INTERFACE ) + 1 ) ) )
+    {
+        printf("ERROR: Invalid argument. \n");
+        return RETURN_ERR;
+    }
+
+    snprintf(Interface, maxSize, "%s", ETH_WAN_IFNAME);
+    return RETURN_OK;
+}
+#endif
 
 /* CcspHalEthSwInit :  */
 /**
@@ -76,7 +191,26 @@ CcspHalEthSwInit
         void
     )
 {
-    return  RETURN_OK;
+#if defined(FEATURE_RDKB_WAN_MANAGER)
+    int rc;
+
+    if (hal_init_done) {
+        return RETURN_OK;
+    }
+
+    // Initialize callback function pointers.
+    ethWanCallbacks.pGWP_act_EthWanLinkUP = NULL;
+    ethWanCallbacks.pGWP_act_EthWanLinkDown = NULL;
+
+    // Create thread to handle async events and callbacks.
+    rc = pthread_create(&ethsw_tid, NULL, ethsw_thread_main, NULL);
+    if (rc != 0) {
+        return RETURN_ERR;
+    }
+
+    hal_init_done = 1;
+#endif
+       	return  RETURN_OK;
 }
 
 
@@ -796,28 +930,36 @@ INT CcspHalExtSw_setEthWanPort(UINT Port)
 	return RETURN_OK;
 }
 
+bool turrisNet_isInterfaceLinkUp(const char *ifname)
+{
+	int  skfd;
+	struct ifreq intf;
+	bool isUp = FALSE;
+
+	if(ifname == NULL) {
+		return FALSE;
+	}
+
+	if ((skfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
+		return FALSE;
+	}
+
+	strcpy(intf.ifr_name, ifname);
+
+	if (ioctl(skfd, SIOCGIFFLAGS, &intf) == -1) {
+		isUp = 0;
+	} else {
+		isUp = (intf.ifr_flags & IFF_RUNNING) ? TRUE : FALSE;
+	}
+
+	close(skfd);
+	return isUp;
+}
+
 INT GWP_GetEthWanLinkStatus()
 {
-    INT status = 0;
-    return status;
+	INT status = 0;
+	status = turrisNet_isInterfaceLinkUp(ETH_WAN_INTERFACE) ? TRUE : FALSE;
+	return status;
 }
 
-void GWP_RegisterEthWan_Callback(appCallBack *obj) {
-    return;
-}
-
-INT GWP_GetEthWanInterfaceName
-(
- unsigned char * Interface,
- ULONG           maxSize
-)
-{
-    //Maxsize param should be minimum 4charecters(eth0) including NULL charecter
-    if( ( Interface == NULL ) || ( maxSize < ( strlen( ETH_WAN_IFNAME ) + 1 ) ) )
-    {
-        printf("ERROR: Invalid argument. \n");
-        return RETURN_ERR;
-    }
-    snprintf(Interface, maxSize, "%s", ETH_WAN_IFNAME);
-    return RETURN_OK;
-}


### PR DESCRIPTION
REFPLTB-1505: Add necessary updates for WanManager support in meta-turris layer

Reason for change: Updating hal-ethsw for wanmanager integeration
Test Procedure: Build and test
Risks: low

Signed-off-by: KaviyaKumaresan <Kaviya.Kumaresan@ltts.com>