### PR TITLE
RDKB-46618: Create HAL definition for getting fw info on banks.

### DIFF
--- a/source/platform/platform_hal.c
+++ b/source/platform/platform_hal.c
@@ -313,3 +313,8 @@ INT platform_hal_GetDhcpv6_Options ( dhcp_opt_list ** req_opt_list, dhcp_opt_lis
     }
     return RETURN_OK;
 }
+
+INT platform_hal_GetFirmwareBankInfo(FW_BANK bankIndex, PFW_BANK_INFO pFW_Bankinfo)
+{
+    return RETURN_OK;
+}


### PR DESCRIPTION
Add stub for platform_hal_GetFirmwareBankInfo
Required by CcspMisc/+/83195