### PR TITLE
RDKB-46920: Create HAL definition to get interface stats.

### DIFF
--- a/source/platform/platform_hal.c
+++ b/source/platform/platform_hal.c
@@ -318,3 +318,8 @@ INT platform_hal_GetFirmwareBankInfo(FW_BANK bankIndex, PFW_BANK_INFO pFW_Bankin
 {
     return RETURN_OK;
 }
+
+INT platform_hal_GetInterfaceStats(const char *ifname,PINTF_STATS pIntfStats)
+{
+    return RETURN_OK;
+}


### PR DESCRIPTION
Reason for change: HAL definition to get interface stats for wan to lan lan-wan traffic.
Add stub code for platform_hal_GetInterfaceStats